### PR TITLE
Added Dashboard Data fetching + Refactored Viewsets

### DIFF
--- a/db_inventory/management/commands/setup_notification_beats.py
+++ b/db_inventory/management/commands/setup_notification_beats.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
                 day_of_month=day,
                 month_of_year=month,
                 day_of_week=dow,
-                timezone=settings.TIME_ZONE,  # ✅ FIX #1
+                timezone=settings.TIME_ZONE,  
             )
 
             PeriodicTask.objects.update_or_create(
@@ -29,7 +29,7 @@ class Command(BaseCommand):
                     "crontab": schedule,
                     "enabled": True,
                     "kwargs": json.dumps({}),
-                    "date_changed": timezone.now(),  # ✅ FIX #2
+                    "date_changed": timezone.now(),  
                 },
             )
 

--- a/db_inventory/mixins.py
+++ b/db_inventory/mixins.py
@@ -10,10 +10,10 @@ from django.utils.text import capfirst
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 from datetime import timedelta
-
-from django.db.models import Count, Sum
+from django.db.models import Count, Sum, Q, F
 from django.utils import timezone
 from rest_framework.response import Response
+
 class ScopeFilterMixin:
     """
     Mixin to automatically filter a queryset based on the user's *active role*.
@@ -584,6 +584,111 @@ class AccessoryDashboardMixin:
                 "used": event_map.get("used", 0),
                 "lost": event_map.get("lost", 0),
                 "damaged": event_map.get("damaged", 0),
+                "condemned": event_map.get("condemned", 0),
+                "restocked": event_map.get("restocked", 0),
+                "adjusted": event_map.get("adjusted", 0),
+            },
+            "meta": {
+                "period_days": period,
+            },
+        }
+
+class ConsumableDashboardMixin:
+    DEFAULT_PERIOD_DAYS = 7
+    MIN_PERIOD_DAYS = 1
+    MAX_PERIOD_DAYS = 30
+
+    def get_rooms(self, public_id):
+        """
+        Must be implemented by the concrete view.
+        Should return a Room queryset.
+        """
+        raise NotImplementedError
+
+    def get_period(self, request):
+        try:
+            period = int(
+                request.query_params.get(
+                    "period", self.DEFAULT_PERIOD_DAYS
+                )
+            )
+        except ValueError:
+            period = self.DEFAULT_PERIOD_DAYS
+
+        return max(self.MIN_PERIOD_DAYS, min(period, self.MAX_PERIOD_DAYS))
+
+    def build_dashboard_response(self, rooms, period):
+        from .models import (
+            Consumable,
+            ConsumableIssue,
+            ConsumableEvent,
+        )
+
+        since = timezone.now() - timedelta(days=period)
+
+        # ─────────────────────────────
+        # Inventory health (NOT time-bound)
+        # ─────────────────────────────
+
+        consumables_qs = Consumable.objects.filter(
+            room__in=rooms
+        )
+
+        summary_base = consumables_qs.aggregate(
+            consumable_types=Count("id"),
+            total_quantity=Sum("quantity"),
+        )
+
+        total_quantity = summary_base["total_quantity"] or 0
+
+        low_stock_count = consumables_qs.filter(
+            quantity__lte=F("low_stock_threshold")
+        ).count()
+
+        out_of_stock_count = consumables_qs.filter(
+            quantity=0
+        ).count()
+
+        # ─────────────────────────────
+        # Flow / usage (time-bound)
+        # ─────────────────────────────
+
+        events_qs = ConsumableEvent.objects.filter(
+            consumable__room__in=rooms,
+            occurred_at__gte=since
+        )
+
+        # Quantity movement per event type
+        event_sums = (
+            events_qs
+            .values("event_type")
+            .annotate(
+                quantity=Sum("quantity_change")
+            )
+        )
+
+        event_map = {
+            row["event_type"]: abs(row["quantity"] or 0)
+            for row in event_sums
+        }
+
+        issued_quantity = event_map.get("issued", 0)
+
+        return {
+            "summary": {
+                "consumable_types": summary_base["consumable_types"],
+                "total_quantity": total_quantity,
+                "low_stock_count": low_stock_count,
+                "out_of_stock_count": out_of_stock_count,
+                "issued_quantity": issued_quantity,
+            },
+            "events": {
+                "issued": event_map.get("issued", 0),
+                "used": event_map.get("used", 0),
+                "returned": event_map.get("returned", 0),
+                "lost": event_map.get("lost", 0),
+                "damaged": event_map.get("damaged", 0),
+                "expired": event_map.get("expired", 0),
                 "condemned": event_map.get("condemned", 0),
                 "restocked": event_map.get("restocked", 0),
                 "adjusted": event_map.get("adjusted", 0),

--- a/db_inventory/mixins.py
+++ b/db_inventory/mixins.py
@@ -9,7 +9,11 @@ from collections import Counter
 from django.utils.text import capfirst
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
+from datetime import timedelta
 
+from django.db.models import Count, Sum
+from django.utils import timezone
+from rest_framework.response import Response
 class ScopeFilterMixin:
     """
     Mixin to automatically filter a queryset based on the user's *active role*.
@@ -491,6 +495,100 @@ class NotificationMixin:
                     "payload": payload,
                 },
             )
-
-        # ✅ Ensure notification fires only after DB commit
         transaction.on_commit(lambda: _create_and_send(recipient))
+
+
+
+class AccessoryDashboardMixin:
+    DEFAULT_PERIOD_DAYS = 7
+    MIN_PERIOD_DAYS = 1
+    MAX_PERIOD_DAYS = 30
+
+    def get_rooms(self, public_id):
+        """
+        Must be implemented by the concrete view.
+        Should return a Room queryset.
+        """
+        raise NotImplementedError
+
+    def get_period(self, request):
+        try:
+            period = int(
+                request.query_params.get(
+                    "period", self.DEFAULT_PERIOD_DAYS
+                )
+            )
+        except ValueError:
+            period = self.DEFAULT_PERIOD_DAYS
+
+        return max(self.MIN_PERIOD_DAYS, min(period, self.MAX_PERIOD_DAYS))
+
+    def build_dashboard_response(self, rooms, period):
+        from .models import (
+            Accessory,
+            AccessoryAssignment,
+            AccessoryEvent,
+        )
+
+        since = timezone.now() - timedelta(days=period)
+
+        accessories_qs = Accessory.objects.filter(
+            room__in=rooms
+        )
+
+        summary = accessories_qs.aggregate(
+            accessory_types=Count("id"),
+            total_quantity=Sum("quantity"),
+        )
+
+        total_quantity = summary["total_quantity"] or 0
+
+        active_assignments_qs = AccessoryAssignment.objects.filter(
+            accessory__room__in=rooms,
+            returned_at__isnull=True
+        )
+
+        assigned_quantity = (
+            active_assignments_qs.aggregate(
+                total=Sum("quantity")
+            )["total"] or 0
+        )
+
+        event_counts = (
+            AccessoryEvent.objects.filter(
+                accessory__room__in=rooms,
+                occurred_at__gte=since
+            )
+            .values("event_type")
+            .annotate(count=Count("id"))
+        )
+
+        event_map = {
+            row["event_type"]: row["count"]
+            for row in event_counts
+        }
+
+        return {
+            "summary": {
+                "accessory_types": summary["accessory_types"],
+                "total_quantity": total_quantity,
+                "assigned_quantity": assigned_quantity,
+                "unassigned_quantity": max(
+                    total_quantity - assigned_quantity, 0
+                ),
+                "active_assignments": active_assignments_qs.count(),
+            },
+            "events": {
+                "assigned": event_map.get("assigned", 0),
+                "returned": event_map.get("returned", 0),
+                "used": event_map.get("used", 0),
+                "lost": event_map.get("lost", 0),
+                "damaged": event_map.get("damaged", 0),
+                "condemned": event_map.get("condemned", 0),
+                "restocked": event_map.get("restocked", 0),
+                "adjusted": event_map.get("adjusted", 0),
+            },
+            "meta": {
+                "period_days": period,
+            },
+        }

--- a/db_inventory/serializers/equipment.py
+++ b/db_inventory/serializers/equipment.py
@@ -2,6 +2,7 @@
 from rest_framework import serializers
 from  db_inventory.models.assets import Equipment, EquipmentStatus
 from db_inventory.models.site import  Room
+from db_inventory.permissions.helpers import is_admin_role, is_in_scope
 
 class EquipmentSerializer(serializers.ModelSerializer):
     is_assigned = serializers.SerializerMethodField()
@@ -154,39 +155,47 @@ class EquipmentStatusChangeSerializer(serializers.Serializer):
     status = serializers.ChoiceField(choices=EquipmentStatus.choices)
     notes = serializers.CharField( required=False, allow_blank=True, trim_whitespace=True, )
 
-    def validate_status(self, new_status):
-        request = self.context["request"]
-        equipment = self.context["equipment"]
-        user = request.user
+def validate_status(self, new_status):
+    request = self.context["request"]
+    equipment = self.context["equipment"]
+    user = request.user
 
-        active_role = getattr(user, "active_role", None)
+    active_role = getattr(user, "active_role", None)
 
-        # --- SITE_ADMIN: unrestricted ---
-        if active_role and active_role.role == "SITE_ADMIN":
-            return new_status
+    # --- SITE_ADMIN: unrestricted ---
+    if active_role and active_role.role == "SITE_ADMIN":
+        return new_status
 
-        # --- Assigned user: limited self-reporting statuses ---
-        assignment = getattr(equipment, "active_assignment", None)
-        if (
-            assignment
-            and assignment.returned_at is None
-            and assignment.user_id == user.id
-        ):
-            allowed_statuses = {
-                EquipmentStatus.OK,
-                EquipmentStatus.DAMAGED,
-                EquipmentStatus.UNDER_REPAIR,
-            }
-            if new_status not in allowed_statuses:
-                raise serializers.ValidationError(
-                    "You can only update the status to OK, DAMAGED, or UNDER_REPAIR."
-                )
-            return new_status
+    # --- Scoped admin: unrestricted ---
+    if (
+        active_role
+        and is_admin_role(active_role.role)
+        and is_in_scope(active_role, room=getattr(equipment, "room", None))
+    ):
+        return new_status
 
-        # --- Everyone else ---
-        raise serializers.ValidationError(
-            "You are not allowed to set this status."
-        )
+    # --- Assigned user: limited self-reporting statuses ---
+    assignment = getattr(equipment, "active_assignment", None)
+    if (
+        assignment
+        and assignment.returned_at is None
+        and assignment.user_id == user.id
+    ):
+        allowed_statuses = {
+            EquipmentStatus.OK,
+            EquipmentStatus.DAMAGED,
+            EquipmentStatus.UNDER_REPAIR,
+        }
+        if new_status not in allowed_statuses:
+            raise serializers.ValidationError(
+                "You can only update the status to OK, DAMAGED, or UNDER_REPAIR."
+            )
+        return new_status
+
+    # --- Everyone else ---
+    raise serializers.ValidationError(
+        "You are not allowed to set this status."
+    )
 
 __all__ = [
     "EquipmentSerializer",

--- a/db_inventory/urls/department_urls.py
+++ b/db_inventory/urls/department_urls.py
@@ -3,41 +3,43 @@ from django.urls import path
 from db_inventory.viewsets.sites import department_viewsets
 
 
+
 urlpatterns = [
     # --- Departments ---
-    path( "", department_viewsets.DepartmentModelViewSet.as_view({ "get": "list", "post": "create", }), name="departments", ),
-    path( "list/", department_viewsets.DepartmentListViewSet.as_view({ "get": "list", }), name="departments-list", ),
-    path( "<str:public_id>/", department_viewsets.DepartmentModelViewSet.as_view({
-            "get": "retrieve",
-            "put": "update",
-            "patch": "partial_update",
-            "delete": "destroy",
-        }), name="department-detail", ),
+    path( "", department_viewsets.DepartmentViewSet.as_view( {"get": "list", "post": "create"} ), name="departments", ),
+    path( "list/", department_viewsets.DepartmentViewSet.as_view( {"get": "list"}, pagination_class=None, ), name="departments-list", ),
+    path( "<str:public_id>/", department_viewsets.DepartmentViewSet.as_view({
+        "get": "retrieve",
+        "put": "update",
+        "patch": "partial_update",
+        "delete": "destroy",
+    }), name="department-detail", ),
 
     # --- Department Users ---
-    path( "<str:public_id>/users-full/", department_viewsets.DepartmentUsersViewSet.as_view({"get": "list"}), name="department-users", ),
-    path( "<str:public_id>/users-light/", department_viewsets.DepartmentUsersMiniViewSet.as_view({"get": "list"}), name="department-users-light", ),
+    path( "<str:public_id>/users/", department_viewsets.DepartmentUsersViewSet.as_view({"get": "list"}), name="department-users", ),
+    path("<str:public_id>/users-light/", department_viewsets.DepartmentUsersViewSet.as_view( {"get": "list"}, pagination_class=None,), name="department-users-light", ),
 
     # --- Department Locations ---
-    path( "<str:public_id>/locations-full/", department_viewsets.DepartmentLocationsViewSet.as_view({"get": "list"}), name="department-locations", ),
-    path( "<str:public_id>/locations-light/", department_viewsets.DepartmentLocationsMiniViewSet.as_view({"get": "list"}), name="department-locations-light", ),
+    path( "<str:public_id>/locations/", department_viewsets.DepartmentLocationsViewSet.as_view({"get": "list"}), name="department-locations", ),
+    path( "<str:public_id>/locations-light/", department_viewsets.DepartmentLocationsViewSet.as_view( {"get": "list"}, pagination_class=None,), name="department-locations-light", ),
     # --- Department Equipment ---
-    path( "<str:public_id>/equipment-full/", department_viewsets.DepartmentEquipmentViewSet.as_view({"get": "list"}), name="department-equipment", ),
+    path( "<str:public_id>/equipment/", department_viewsets.DepartmentEquipmentViewSet.as_view({"get": "list"}), name="department-equipment", ),
     path( "<str:public_id>/equipment/dashboard/", department_viewsets.DepartmentEquipmentDashboardView.as_view(), name="department-equipment-dashboard", ),
-    path( "<str:public_id>/equipment-light/", department_viewsets.DepartmentEquipmentMiniViewSet.as_view({"get": "list"}), name="department-equipment-light", ),
+    path( "<str:public_id>/equipment-light/", department_viewsets.DepartmentEquipmentViewSet.as_view({"get": "list"},pagination_class=None,), name="department-equipment-light", ),
     # --- Department Consumables ---
-    path( "<str:public_id>/consumables-full/", department_viewsets.DepartmentConsumablesViewSet.as_view({"get": "list"}), name="department-consumables", ),
+    path( "<str:public_id>/consumables/", department_viewsets.DepartmentConsumablesViewSet.as_view({"get": "list"}), name="department-consumables", ),
     path( "<str:public_id>/consumables/dashboard/", department_viewsets.DepartmentConsumableDashboardView.as_view(), name="department-consumables-dashboard", ),
-    path( "<str:public_id>/consumables-light/", department_viewsets.DepartmentConsumablesMiniViewSet.as_view({"get": "list"}), name="department-consumables-light", ),
+    path( "<str:public_id>/consumables-light/", department_viewsets.DepartmentConsumablesViewSet.as_view({"get": "list"}, pagination_class=None,), name="department-consumables-light", ),
 
     # --- Department Accessories ---
-    path( "<str:public_id>/accessories-full/", department_viewsets.DepartmentAccessoriesViewSet.as_view({"get": "list"}), name="department-accessories", ),
+    path( "<str:public_id>/accessories/", department_viewsets.DepartmentAccessoriesViewSet.as_view({"get": "list"}), name="department-accessories", ),
     path( "<str:public_id>/accessories/dashboard/", department_viewsets.DepartmentAccessoryDashboardView.as_view(), name="department-accessories-dashboard", ),
-    path( "<str:public_id>/accessories-light/", department_viewsets.DepartmentAccessoriesMiniViewSet.as_view({"get": "list"}), name="department-accessories-light", ),
+    path( "<str:public_id>/accessories-light/", department_viewsets.DepartmentAccessoriesViewSet.as_view({"get": "list"}, pagination_class=None,), name="department-accessories-light", ),
 
     # --- Department Components ---
-    path( "<str:public_id>/components-full/", department_viewsets.DepartmentComponentsViewSet.as_view({"get": "list"}), name="department-components", ),
-    path( "<str:public_id>/components-light/", department_viewsets.DepartmentComponentsMiniViewSet.as_view({"get": "list"}), name="department-components-light", ),
+    path( "<str:public_id>/components/", department_viewsets.DepartmentComponentsViewSet.as_view({"get": "list"}), name="department-components", ),
+    path( "<str:public_id>/components-light/", department_viewsets.DepartmentComponentsMiniViewSet.as_view({"get": "list"}, pagination_class=None,), name="department-components-light", ),
+
     # --- Department Roles ---
     path( "<str:public_id>/roles/", department_viewsets.DepartmentRolesViewSet.as_view({"get": "list"}), name="department-roles", ),
 

--- a/db_inventory/urls/department_urls.py
+++ b/db_inventory/urls/department_urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path( "<str:public_id>/equipment-light/", department_viewsets.DepartmentEquipmentMiniViewSet.as_view({"get": "list"}), name="department-equipment-light", ),
     # --- Department Consumables ---
     path( "<str:public_id>/consumables-full/", department_viewsets.DepartmentConsumablesViewSet.as_view({"get": "list"}), name="department-consumables", ),
+    path( "<str:public_id>/consumables/dashboard/", department_viewsets.DepartmentConsumableDashboardView.as_view(), name="department-consumables-dashboard", ),
     path( "<str:public_id>/consumables-light/", department_viewsets.DepartmentConsumablesMiniViewSet.as_view({"get": "list"}), name="department-consumables-light", ),
 
     # --- Department Accessories ---

--- a/db_inventory/urls/department_urls.py
+++ b/db_inventory/urls/department_urls.py
@@ -38,7 +38,7 @@ urlpatterns = [
 
     # --- Department Components ---
     path( "<str:public_id>/components/", department_viewsets.DepartmentComponentsViewSet.as_view({"get": "list"}), name="department-components", ),
-    path( "<str:public_id>/components-light/", department_viewsets.DepartmentComponentsMiniViewSet.as_view({"get": "list"}, pagination_class=None,), name="department-components-light", ),
+    path( "<str:public_id>/components-light/", department_viewsets.DepartmentComponentsViewSet.as_view({"get": "list"}, pagination_class=None,), name="department-components-light", ),
 
     # --- Department Roles ---
     path( "<str:public_id>/roles/", department_viewsets.DepartmentRolesViewSet.as_view({"get": "list"}), name="department-roles", ),

--- a/db_inventory/urls/department_urls.py
+++ b/db_inventory/urls/department_urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
 
     # --- Department Accessories ---
     path( "<str:public_id>/accessories-full/", department_viewsets.DepartmentAccessoriesViewSet.as_view({"get": "list"}), name="department-accessories", ),
+    path( "<str:public_id>/accessories/dashboard/", department_viewsets.DepartmentAccessoryDashboardView.as_view(), name="department-accessories-dashboard", ),
     path( "<str:public_id>/accessories-light/", department_viewsets.DepartmentAccessoriesMiniViewSet.as_view({"get": "list"}), name="department-accessories-light", ),
 
     # --- Department Components ---

--- a/db_inventory/urls/department_urls.py
+++ b/db_inventory/urls/department_urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     path( "<str:public_id>/locations-light/", department_viewsets.DepartmentLocationsMiniViewSet.as_view({"get": "list"}), name="department-locations-light", ),
     # --- Department Equipment ---
     path( "<str:public_id>/equipment-full/", department_viewsets.DepartmentEquipmentViewSet.as_view({"get": "list"}), name="department-equipment", ),
+    path( "<str:public_id>/equipment/dashboard/", department_viewsets.DepartmentEquipmentDashboardView.as_view(), name="department-equipment-dashboard", ),
     path( "<str:public_id>/equipment-light/", department_viewsets.DepartmentEquipmentMiniViewSet.as_view({"get": "list"}), name="department-equipment-light", ),
     # --- Department Consumables ---
     path( "<str:public_id>/consumables-full/", department_viewsets.DepartmentConsumablesViewSet.as_view({"get": "list"}), name="department-consumables", ),

--- a/db_inventory/urls/location_urls.py
+++ b/db_inventory/urls/location_urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
 
     # --- Location Equipment ---
     path( "<str:public_id>/equipment-full/", location_viewsets.LocationEquipmentView.as_view({"get": "list"}), name="location-equipment", ),
+    path( "<str:public_id>/equipment/dashboard/", location_viewsets.LocationEquipmentDashboardView.as_view(), name="location-equipment-dashboard", ),
     path( "<str:public_id>/equipment-light/", location_viewsets.LocationEquipmentMiniViewSet.as_view({"get": "list"}), name="location-equipment-light", ),
     # --- Location Consumables ---
     path( "<str:public_id>/consumables-full/", location_viewsets.LocationConsumablesView.as_view({"get": "list"}), name="location-consumables", ),

--- a/db_inventory/urls/location_urls.py
+++ b/db_inventory/urls/location_urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path( "<str:public_id>/equipment-light/", location_viewsets.LocationEquipmentMiniViewSet.as_view({"get": "list"}), name="location-equipment-light", ),
     # --- Location Consumables ---
     path( "<str:public_id>/consumables-full/", location_viewsets.LocationConsumablesView.as_view({"get": "list"}), name="location-consumables", ),
+    path( "<str:public_id>/consumables/dashboard/", location_viewsets.LocationConsumableDashboardView.as_view(), name="location-consumables-dashboard", ),
     path( "<str:public_id>/consumables-light/", location_viewsets.LocationConsumablesMiniViewSet.as_view({"get": "list"}), name="location-consumables-light", ),
 
     # --- Location Accessories ---

--- a/db_inventory/urls/location_urls.py
+++ b/db_inventory/urls/location_urls.py
@@ -5,39 +5,39 @@ from db_inventory.viewsets.sites import location_viewsets
 
 urlpatterns = [
     # --- Locations ---
-    path( "", location_viewsets.LocationModelViewSet.as_view({ "get": "list", "post": "create", }), name="locations", ),
-    path( "list/", location_viewsets.LocationListViewSet.as_view({ "get": "list", }), name="locations-list", ),
-    path( "<str:public_id>/", location_viewsets.LocationModelViewSet.as_view({
-            "get": "retrieve",
-            "put": "update",
-            "patch": "partial_update",
-            "delete": "destroy",
-        }), name="location-detail", ),
+    path( "", location_viewsets.LocationViewSet.as_view( {"get": "list", "post": "create"} ), name="locations", ),
+    path( "list/", location_viewsets.LocationViewSet.as_view( {"get": "list"}, pagination_class=None, ), name="locations-list", ),
+    path( "<str:public_id>/", location_viewsets.LocationViewSet.as_view({
+        "get": "retrieve",
+        "put": "update",
+        "patch": "partial_update",
+        "delete": "destroy",
+    }), name="location-detail", ),
         
     # --- Location Rooms ---
-    path( "<str:public_id>/rooms-full/", location_viewsets.LocationRoomsView.as_view({"get": "list"}), name="location-rooms", ),
-    path( "<str:public_id>/rooms-light/", location_viewsets.LocationRoomsMiniViewSet.as_view({"get": "list"}), name="location-rooms-light", ),
+    path( "<str:public_id>/rooms/", location_viewsets.LocationRoomsView.as_view({"get": "list"}), name="location-rooms", ),
+    path( "<str:public_id>/rooms-light/", location_viewsets.LocationRoomsView.as_view({"get": "list"},pagination_class=None,), name="location-rooms-light", ),
 
     # --- Location Users ---
-    path( "<str:public_id>/users-full/", location_viewsets.LocationUsersView.as_view({"get": "list"}), name="location-users", ),
-    path( "<str:public_id>/users-light/", location_viewsets.LocationUsersMiniViewSet.as_view({"get": "list"}), name="location-users-light", ),
+    path( "<str:public_id>/users/", location_viewsets.LocationUsersView.as_view({"get": "list"}), name="location-users", ),
+    path( "<str:public_id>/users-light/", location_viewsets.LocationUsersView.as_view({"get": "list"},pagination_class=None,), name="location-users-light", ),
 
     # --- Location Equipment ---
-    path( "<str:public_id>/equipment-full/", location_viewsets.LocationEquipmentView.as_view({"get": "list"}), name="location-equipment", ),
+    path( "<str:public_id>/equipment/", location_viewsets.LocationEquipmentView.as_view({"get": "list"}), name="location-equipment", ),
     path( "<str:public_id>/equipment/dashboard/", location_viewsets.LocationEquipmentDashboardView.as_view(), name="location-equipment-dashboard", ),
-    path( "<str:public_id>/equipment-light/", location_viewsets.LocationEquipmentMiniViewSet.as_view({"get": "list"}), name="location-equipment-light", ),
+    path( "<str:public_id>/equipment-light/", location_viewsets.LocationEquipmentView.as_view({"get": "list"},pagination_class=None,), name="location-equipment-light", ),
     # --- Location Consumables ---
-    path( "<str:public_id>/consumables-full/", location_viewsets.LocationConsumablesView.as_view({"get": "list"}), name="location-consumables", ),
+    path( "<str:public_id>/consumables/", location_viewsets.LocationConsumablesView.as_view({"get": "list"}), name="location-consumables", ),
     path( "<str:public_id>/consumables/dashboard/", location_viewsets.LocationConsumableDashboardView.as_view(), name="location-consumables-dashboard", ),
-    path( "<str:public_id>/consumables-light/", location_viewsets.LocationConsumablesMiniViewSet.as_view({"get": "list"}), name="location-consumables-light", ),
+    path( "<str:public_id>/consumables-light/", location_viewsets.LocationConsumablesView.as_view({"get": "list"},pagination_class=None,), name="location-consumables-light", ),
 
     # --- Location Accessories ---
-    path( "<str:public_id>/accessories-full/", location_viewsets.LocationAccessoriesView.as_view({"get": "list"}), name="location-accessories", ),
+    path( "<str:public_id>/accessories/", location_viewsets.LocationAccessoriesView.as_view({"get": "list"},pagination_class=None,), name="location-accessories", ),
     path( "<str:public_id>/accessories/dashboard/", location_viewsets.LocationAccessoryDashboardView.as_view(), name="location-accessories-dashboard", ),
-    path( "<str:public_id>/accessories-light/", location_viewsets.LocationAccessoriesMiniViewSet.as_view({"get": "list"}), name="location-accessories-light", ),
+    path( "<str:public_id>/accessories-light/", location_viewsets.LocationAccessoriesView.as_view({"get": "list"},pagination_class=None,), name="location-accessories-light", ),
     # --- Location Components ---
-    path( "<str:public_id>/components-full/", location_viewsets.LocationComponentsViewSet.as_view({"get": "list"}), name="location-components", ),
-    path( "<str:public_id>/components-light/", location_viewsets.LocationComponentsMiniViewSet.as_view({"get": "list"}), name="location-components-light", ),
+    path( "<str:public_id>/components/", location_viewsets.LocationComponentsViewSet.as_view({"get": "list"}), name="location-components", ),
+    path( "<str:public_id>/components-light/", location_viewsets.LocationComponentsViewSet.as_view({"get": "list"},pagination_class=None,), name="location-components-light", ),
 
     # --- Location Roles ---
     path( "<str:public_id>/roles/", location_viewsets.LocationRolesViewSet.as_view({"get": "list"}), name="location-roles", ),

--- a/db_inventory/urls/location_urls.py
+++ b/db_inventory/urls/location_urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
 
     # --- Location Accessories ---
     path( "<str:public_id>/accessories-full/", location_viewsets.LocationAccessoriesView.as_view({"get": "list"}), name="location-accessories", ),
+    path( "<str:public_id>/accessories/dashboard/", location_viewsets.LocationAccessoryDashboardView.as_view(), name="location-accessories-dashboard", ),
     path( "<str:public_id>/accessories-light/", location_viewsets.LocationAccessoriesMiniViewSet.as_view({"get": "list"}), name="location-accessories-light", ),
     # --- Location Components ---
     path( "<str:public_id>/components-full/", location_viewsets.LocationComponentsViewSet.as_view({"get": "list"}), name="location-components", ),

--- a/db_inventory/urls/room_urls.py
+++ b/db_inventory/urls/room_urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path( "<str:public_id>/equipment-light/", room_viewsets.RoomEquipmentMiniViewSet.as_view({"get": "list"}), name="room-equipment-light", ),
     # --- Room Consumables ---
     path( "<str:public_id>/consumables-full/", room_viewsets.RoomConsumablesViewSet.as_view({"get": "list"}), name="room-consumables", ),
+    path( "<str:public_id>/consumables/dashboard/", room_viewsets.RoomConsumableDashboardView.as_view(), name="room-consumables-dashboard", ),
     path( "<str:public_id>/consumables-light/", room_viewsets.RoomConsumablesMiniViewSet.as_view({"get": "list"}), name="room-consumables-light", ),
 
     # --- Room Accessories ---

--- a/db_inventory/urls/room_urls.py
+++ b/db_inventory/urls/room_urls.py
@@ -8,35 +8,35 @@ from db_inventory.viewsets.sites import room_viewsets
 
 urlpatterns = [
     # --- Rooms ---
-    path( "", room_viewsets.RoomModelViewSet.as_view({ "get": "list", "post": "create", }), name="rooms", ),
-    path( "list/", room_viewsets.RoomListViewset.as_view({ "get": "list", }), name="rooms-list", ),
-    path( "<str:public_id>/", room_viewsets.RoomModelViewSet.as_view({
-            "get": "retrieve",
-            "put": "update",
-            "patch": "partial_update",
-            "delete": "destroy",
-        }), name="room-detail", ),
+    path( "", room_viewsets.RoomViewSet.as_view({"get": "list", "post": "create"}), name="rooms", ),
+    path( "list/", room_viewsets.RoomViewSet.as_view( {"get": "list"}, pagination_class=None, ), name="rooms-list", ),
+    path( "<str:public_id>/", room_viewsets.RoomViewSet.as_view({
+        "get": "retrieve",
+        "put": "update",
+        "patch": "partial_update",
+        "delete": "destroy",
+    }), name="room-detail", ),
 
     # --- Room Users ---
-    path( "<str:public_id>/users-full/", room_viewsets.RoomUsersViewSet.as_view({"get": "list"}), name="room-users", ),
-    path( "<str:public_id>/users-light/", room_viewsets.RoomUsersMiniViewSet.as_view({"get": "list"}), name="room-users-light", ),
+    path( "<str:public_id>/users/", room_viewsets.RoomUsersViewSet.as_view({"get": "list"}), name="room-users", ),
+    path( "<str:public_id>/users-light/", room_viewsets.RoomUsersViewSet.as_view({"get": "list"},pagination_class=None,), name="room-users-light", ),
     # --- Room Equipment ---
-    path( "<str:public_id>/equipment-full/", room_viewsets.RoomEquipmentViewSet.as_view({"get": "list"}), name="room-equipment", ),
+    path( "<str:public_id>/equipment/", room_viewsets.RoomEquipmentViewSet.as_view({"get": "list"}), name="room-equipment", ),
     path( "<str:public_id>/equipment/dashboard/", room_viewsets.RoomEquipmentDashboardView.as_view(), name="room-equipment-dashboard", ),
-    path( "<str:public_id>/equipment-light/", room_viewsets.RoomEquipmentMiniViewSet.as_view({"get": "list"}), name="room-equipment-light", ),
+    path( "<str:public_id>/equipment-light/", room_viewsets.RoomUsersViewSet.as_view({"get": "list"},pagination_class=None,), name="room-equipment-light", ),
     # --- Room Consumables ---
-    path( "<str:public_id>/consumables-full/", room_viewsets.RoomConsumablesViewSet.as_view({"get": "list"}), name="room-consumables", ),
+    path( "<str:public_id>/consumables/", room_viewsets.RoomConsumablesViewSet.as_view({"get": "list"}), name="room-consumables", ),
     path( "<str:public_id>/consumables/dashboard/", room_viewsets.RoomConsumableDashboardView.as_view(), name="room-consumables-dashboard", ),
-    path( "<str:public_id>/consumables-light/", room_viewsets.RoomConsumablesMiniViewSet.as_view({"get": "list"}), name="room-consumables-light", ),
+    path( "<str:public_id>/consumables-light/", room_viewsets.RoomUsersViewSet.as_view({"get": "list"},pagination_class=None,), name="room-consumables-light", ),
 
     # --- Room Accessories ---
-    path( "<str:public_id>/accessories-full/", room_viewsets.RoomAccessoriesViewSet.as_view({"get": "list"}), name="room-accessories", ),
+    path( "<str:public_id>/accessories/", room_viewsets.RoomAccessoriesViewSet.as_view({"get": "list"}), name="room-accessories", ),
     path( "<str:public_id>/accessories/dashboard/", room_viewsets.RoomAccessoryDashboardView.as_view(), name="room-accessories-dashboard", ),
-    path( "<str:public_id>/accessories-light/", room_viewsets.RoomAccessoriesMiniViewSet.as_view({"get": "list"}), name="room-accessories-light", ),
+    path( "<str:public_id>/accessories-light/", room_viewsets.RoomUsersViewSet.as_view({"get": "list"},pagination_class=None,), name="room-accessories-light", ),
 
     # --- Room Components ---
-    path( "<str:public_id>/components-full/", room_viewsets.RoomComponentsViewSet.as_view({"get": "list"}), name="room-components", ),
-    path( "<str:public_id>/components-light/", room_viewsets.RoomComponentsMiniViewSet.as_view({"get": "list"}), name="room-components-light", ),
+    path( "<str:public_id>/components/", room_viewsets.RoomComponentsViewSet.as_view({"get": "list"}), name="room-components", ),
+    path( "<str:public_id>/components-light/", room_viewsets.RoomComponentsViewSet.as_view({"get": "list"},pagination_class=None,), name="room-components-light", ),
 
     # --- Room Roles ---
     path( "<str:public_id>/roles/", room_viewsets.RoomRolesViewSet.as_view({"get": "list"}), name="room-roles", ),

--- a/db_inventory/urls/room_urls.py
+++ b/db_inventory/urls/room_urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
 
     # --- Room Accessories ---
     path( "<str:public_id>/accessories-full/", room_viewsets.RoomAccessoriesViewSet.as_view({"get": "list"}), name="room-accessories", ),
+    path( "<str:public_id>/accessories/dashboard/", room_viewsets.RoomAccessoryDashboardView.as_view(), name="room-accessories-dashboard", ),
     path( "<str:public_id>/accessories-light/", room_viewsets.RoomAccessoriesMiniViewSet.as_view({"get": "list"}), name="room-accessories-light", ),
 
     # --- Room Components ---

--- a/db_inventory/urls/room_urls.py
+++ b/db_inventory/urls/room_urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path( "<str:public_id>/users-light/", room_viewsets.RoomUsersMiniViewSet.as_view({"get": "list"}), name="room-users-light", ),
     # --- Room Equipment ---
     path( "<str:public_id>/equipment-full/", room_viewsets.RoomEquipmentViewSet.as_view({"get": "list"}), name="room-equipment", ),
+    path( "<str:public_id>/equipment/dashboard/", room_viewsets.RoomEquipmentDashboardView.as_view(), name="room-equipment-dashboard", ),
     path( "<str:public_id>/equipment-light/", room_viewsets.RoomEquipmentMiniViewSet.as_view({"get": "list"}), name="room-equipment-light", ),
     # --- Room Consumables ---
     path( "<str:public_id>/consumables-full/", room_viewsets.RoomConsumablesViewSet.as_view({"get": "list"}), name="room-consumables", ),

--- a/db_inventory/viewsets/sites/department_viewsets.py
+++ b/db_inventory/viewsets/sites/department_viewsets.py
@@ -24,68 +24,46 @@ from db_inventory.models.assets import EquipmentStatus
 from rest_framework.views import APIView
 
 
+class DepartmentViewSet(AuditMixin, ScopeFilterMixin, viewsets.ModelViewSet):
+    """ViewSet for managing Department objects"""
 
-class DepartmentModelViewSet(AuditMixin,ScopeFilterMixin, viewsets.ModelViewSet):
-
-    """ViewSet for managing Department objects.
-    This viewset provides `list`, `create`, actions for Department objects."""
-
-    queryset = Department.objects.all().order_by('-id')
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
+    permission_classes = [DepartmentPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    permission_classes=[DepartmentPermission]
+    search_fields = ["name"]
+    filterset_class = DepartmentFilter
 
     pagination_class = FlexiblePagination
-    
-
-    filterset_class = DepartmentFilter
-    
 
     def get_serializer_class(self):
-        if self.action in ['create', 'update', 'partial_update']:
+        if self.action in ["create", "update", "partial_update"]:
             return DepartmentWriteSerializer
+
+        # Flat list endpoint (unpaginated)
+        if self.action == "list" and self.pagination_class is None:
+            return DepartmentListSerializer
+
         return DepartmentSerializer
 
-class DepartmentListViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
+    def get_queryset(self):
+        return Department.objects.all().order_by("-id")
 
-    """Returns a flat list of department objects"""
-
-    queryset = Department.objects.all()
-    lookup_field = 'public_id'
-
-    permission_classes=[DepartmentPermission]
-
-    filter_backends = [SearchFilter]
-    search_fields = ['name']
-    pagination_class = None 
-
-    serializer_class = DepartmentListSerializer
-
-
-
-class DepartmentUsersViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet, ExcludeFiltersMixin):
-    """Retrieves a list of users in a given department"""
+class DepartmentUsersViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     serializer_class = UserAreaSerializer
+    permission_classes = [UserPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['user__email']
+    search_fields = ["user__email"]
     exclude_filter_fields = ["department"]
-
-    permission_classes=[UserPermission]
-
-
     filterset_class = AreaUserFilter
 
     pagination_class = FlexiblePagination
 
-    
     def get_queryset(self):
-        department_id = self.kwargs.get("public_id")
+        department_id = self.kwargs["public_id"]
 
-        return (
+        qs = (
             UserLocation.objects.filter(is_current=True)
             .filter(
                 Q(room__location__department__public_id=department_id)
@@ -105,110 +83,75 @@ class DepartmentUsersViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet, Ex
             .order_by("-id")
         )
 
-    
+        # Light endpoint → no pagination → hard cap
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
+        kwargs["exclude_department"] = True
         return super().get_serializer(*args, **kwargs)
-    
-    
-class DepartmentUsersMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    """
-    Lightweight, read-only version for dashboard:
-    last 20 users of a department, ordered by most recent (-id).
-    Pagination disabled.
-    """
-    serializer_class = UserAreaSerializer
-    pagination_class = None  # disables global pagination
 
-    permission_classes=[UserPermission]
-
-    def get_queryset(self):
-        department_id = self.kwargs.get("public_id")
-
-        return (
-            UserLocation.objects.filter(is_current=True)
-            .filter(
-                Q(room__location__department__public_id=department_id)
-                | Q(
-                    user__created_by__user_locations__is_current=True,
-                    user__created_by__user_locations__room__location__department__public_id=department_id
-                )
-                | Q(user__role_assignments__department__public_id=department_id)
-            )
-            .select_related(
-                "user",
-                "room",
-                "room__location",
-                "room__location__department",
-            )
-            .distinct()
-            .order_by("-id")[:20] )
-
-class DepartmentLocationsViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet, ExcludeFiltersMixin):
+class DepartmentLocationsViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     serializer_class = DepartmentLocationsLightSerializer
-    filter_backends = [DjangoFilterBackend, SearchFilter]
+    permission_classes = [LocationPermission]
 
-    search_fields = ['name']
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    search_fields = ["name"]
     filterset_class = LocationFilter
     exclude_filter_fields = ["department"]
 
-    permission_classes=[LocationPermission]
-
     pagination_class = FlexiblePagination
-
-    lookup_field = 'public_id'
-
+    lookup_field = "public_id"
 
     def get_queryset(self):
-        department_id = self.kwargs.get("public_id")
+        department_id = self.kwargs["public_id"]
 
-        return (
+        qs = (
             Location.objects
             .filter(department__public_id=department_id)
-            .annotate(room_count=Count('rooms'))  
+            .annotate(room_count=Count("rooms"))
+            .order_by("-id")
         )
 
-class DepartmentLocationsMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = DepartmentLocationsLightSerializer
-    lookup_field = 'public_id'
-    pagination_class = None  # disable global pagination
-    permission_classes=[LocationPermission]
+        # Light endpoint (dashboard)
+        if self.pagination_class is None:
+            qs = qs[:20]
 
-    def get_queryset(self):
-        department_id = self.kwargs.get("public_id")
-        return (
-            Location.objects.filter(department__public_id=department_id)
-            .annotate(room_count=Count('rooms'))
-            .order_by('-id')[:20]  
-        )
+        return qs
 
-
-class DepartmentEquipmentViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet, ExcludeFiltersMixin):
+class DepartmentEquipmentViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     """Retrieves a list of equipment in a given department"""
     serializer_class = EquipmentSerializer
-    lookup_field = 'public_id'
-
-    permission_classes=[AssetPermission]
+    lookup_field = "public_id"
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    exclude_filter_fields = ["department"]
-
+    search_fields = ["name"]
     filterset_class = EquipmentFilter
+    exclude_filter_fields = ["department"]
 
     pagination_class = FlexiblePagination
 
     def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return Equipment.objects.filter(room__location__department__public_id=department_id).order_by('-id')
-    
+        department_id = self.kwargs["public_id"]
+
+        qs = (
+            Equipment.objects
+            .filter(room__location__department__public_id=department_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint (dashboard / small lists)
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
+        kwargs["exclude_department"] = True
         return super().get_serializer(*args, **kwargs)
-    
 
 class DepartmentEquipmentDashboardView(APIView):
     permission_classes = [IsAuthenticated]
@@ -264,49 +207,38 @@ class DepartmentEquipmentDashboardView(APIView):
             },
         })
 
-class DepartmentEquipmentMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = EquipmentSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
 
-    permission_classes=[AssetPermission]
-
-    def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return (
-            Equipment.objects.filter(room__location__department__public_id=department_id)
-            .order_by('-id')[:20]
-        )
-    
-    def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
-        return super().get_serializer(*args, **kwargs)
-
-
-class DepartmentConsumablesViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet, ExcludeFiltersMixin):
+class DepartmentConsumablesViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     """Retrieves a list of consumables in a given department"""
     serializer_class = ConsumableAreaReaSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
+
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    permission_classes=[AssetPermission]
-
-    exclude_filter_fields = ["department"]
-
+    search_fields = ["name"]
     filterset_class = ConsumableFilter
+    exclude_filter_fields = ["department"]
 
     pagination_class = FlexiblePagination
 
     def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return Consumable.objects.filter(room__location__department__public_id=department_id).order_by('-id')
-    
+        department_id = self.kwargs["public_id"]
+
+        qs = (
+            Consumable.objects
+            .filter(room__location__department__public_id=department_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
+        kwargs["exclude_department"] = True
         return super().get_serializer(*args, **kwargs)
     
 class DepartmentConsumableDashboardView( ConsumableDashboardMixin, APIView):
@@ -324,49 +256,38 @@ class DepartmentConsumableDashboardView( ConsumableDashboardMixin, APIView):
         data = self.build_dashboard_response(rooms, period)
         return Response(data)
 
-class DepartmentConsumablesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = ConsumableAreaReaSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
 
-    permission_classes=[AssetPermission]
-
-    def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return (
-            Consumable.objects.filter(room__location__department__public_id=department_id)
-            .order_by('-id')[:20]
-        )
-    
-    def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
-        return super().get_serializer(*args, **kwargs)
-
-class DepartmentAccessoriesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet):
+class DepartmentAccessoriesViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     """Retrieves a list of accessories in a given department"""
     serializer_class = AccessoryFullSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
 
-    permission_classes=[AssetPermission]
-
-    filterset_class = AccessoryFilter
-
-    exclude_filter_fields = ["department"]
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
+    search_fields = ["name"]
+    filterset_class = AccessoryFilter
+    exclude_filter_fields = ["department"]
 
     pagination_class = FlexiblePagination
 
- 
     def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return Accessory.objects.filter(room__location__department__public_id=department_id).order_by('-id')
-    
+        department_id = self.kwargs["public_id"]
+
+        qs = (
+            Accessory.objects
+            .filter(room__location__department__public_id=department_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
+        kwargs["exclude_department"] = True
         return super().get_serializer(*args, **kwargs)
     
 
@@ -388,64 +309,39 @@ class DepartmentAccessoryDashboardView(
         data = self.build_dashboard_response(rooms, period)
         return Response(data)
     
-class DepartmentAccessoriesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = AccessoryFullSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
 
-    permission_classes=[AssetPermission]
 
-    def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return (
-            Accessory.objects.filter(room__location__department__public_id=department_id)
-            .order_by('-id')[:20]
-        )
-
-    def get_serializer(self, *args, **kwargs):
-        # Exclude department fields for this department-level view
-        kwargs['exclude_department'] = True
-        return super().get_serializer(*args, **kwargs)    
-
-class DepartmentComponentsViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet):
+class DepartmentComponentsViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     """Retrieves a list of components in a given department"""
     serializer_class = DepartmentComponentSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
 
-    permission_classes=[AssetPermission]
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
+    search_fields = ["name"]
+    filterset_class = ComponentFilter
     exclude_filter_fields = ["department"]
 
-    filterset_class = ComponentFilter
-
     pagination_class = FlexiblePagination
-    
-
 
     def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return Component.objects.filter(equipment__room__location__department__public_id=department_id).order_by('-id')
-    
-    
+        department_id = self.kwargs["public_id"]
 
-class DepartmentComponentsMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = DepartmentComponentSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-
-    permission_classes=[AssetPermission]
-
-    def get_queryset(self):
-        department_id = self.kwargs.get('public_id')
-        return (
-            Component.objects.filter(equipment__room__location__department__public_id=department_id)
-            .order_by('-id')[:20]
+        qs = (
+            Component.objects
+            .filter(
+                equipment__room__location__department__public_id=department_id
+            )
+            .order_by("-id")
         )
-    
 
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+    
 class DepartmentRolesViewSet(ScopeFilterMixin,RoleVisibilityMixin,viewsets.ReadOnlyModelViewSet):
     """
     Retrieves a list of users and their roles in a given department
@@ -479,32 +375,34 @@ class DepartmentRolesViewSet(ScopeFilterMixin,RoleVisibilityMixin,viewsets.ReadO
         return qs.order_by("-id")
     
 
-class DepartmentRoomsViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet, ExcludeFiltersMixin):
+class DepartmentRoomsViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     serializer_class = RoomSerializer
-    filter_backends = [DjangoFilterBackend, SearchFilter]
+    lookup_field = "public_id"
 
-    search_fields = ['name']
+    permission_classes = [RoomPermission]
+
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    search_fields = ["name"]
     filterset_class = RoomFilter
     exclude_filter_fields = ["department", "location"]
 
-    permission_classes=[RoomPermission]
-
     pagination_class = FlexiblePagination
 
-    lookup_field = 'public_id'
-
-
     def get_queryset(self):
-        department_id = self.kwargs.get("public_id")
+        department_id = self.kwargs["public_id"]
 
-        return (
+        qs = (
             Room.objects
             .filter(location__department__public_id=department_id)
-            .select_related("location", "location__department") 
+            .select_related("location", "location__department")
             .order_by("location__name", "name")
         )
 
-# ASSIGNMENT
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
 
 class DepartmentEquipmentAssignmentViewSet(
     mixins.ListModelMixin,

--- a/db_inventory/viewsets/sites/department_viewsets.py
+++ b/db_inventory/viewsets/sites/department_viewsets.py
@@ -6,7 +6,7 @@ from db_inventory.filters import *
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from django.db.models import Count  
-from db_inventory.mixins import AccessoryDashboardMixin, ScopeFilterMixin, ExcludeFiltersMixin, AuditMixin, RoleVisibilityMixin
+from db_inventory.mixins import AccessoryDashboardMixin, ConsumableDashboardMixin, ScopeFilterMixin, ExcludeFiltersMixin, AuditMixin, RoleVisibilityMixin
 from db_inventory.permissions import DepartmentPermission, UserPermission, LocationPermission, AssetPermission, RolePermission, RoomPermission
 from db_inventory.pagination import  FlexiblePagination
 from django.db.models import Q
@@ -309,7 +309,20 @@ class DepartmentConsumablesViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewS
         kwargs['exclude_department'] = True
         return super().get_serializer(*args, **kwargs)
     
+class DepartmentConsumableDashboardView( ConsumableDashboardMixin, APIView):
+    permission_classes = [IsAuthenticated]
 
+    def get_rooms(self, public_id):
+        return Room.objects.filter(
+            location__department__public_id=public_id
+        )
+
+    def get(self, request, public_id):
+        rooms = self.get_rooms(public_id)
+        period = self.get_period(request)
+
+        data = self.build_dashboard_response(rooms, period)
+        return Response(data)
 
 class DepartmentConsumablesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = ConsumableAreaReaSerializer

--- a/db_inventory/viewsets/sites/department_viewsets.py
+++ b/db_inventory/viewsets/sites/department_viewsets.py
@@ -6,7 +6,7 @@ from db_inventory.filters import *
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from django.db.models import Count  
-from db_inventory.mixins import ScopeFilterMixin, ExcludeFiltersMixin, AuditMixin, RoleVisibilityMixin
+from db_inventory.mixins import AccessoryDashboardMixin, ScopeFilterMixin, ExcludeFiltersMixin, AuditMixin, RoleVisibilityMixin
 from db_inventory.permissions import DepartmentPermission, UserPermission, LocationPermission, AssetPermission, RolePermission, RoomPermission
 from db_inventory.pagination import  FlexiblePagination
 from django.db.models import Q
@@ -240,7 +240,7 @@ class DepartmentEquipmentDashboardView(APIView):
             returned_at__isnull=True
         ).count()
 
-        available = equipment_qs.filter(
+        ok_unassigned = equipment_qs.filter(
             status=EquipmentStatus.OK,
             active_assignment__returned_at__isnull=True
         ).count()
@@ -248,7 +248,7 @@ class DepartmentEquipmentDashboardView(APIView):
         return Response({
             "equipment_health": {
                 "total": total_equipment,
-                "available": available,
+                "available": ok_unassigned,
                 "under_repair": status_map.get(EquipmentStatus.UNDER_REPAIR, 0),
                 "ok": status_map.get(EquipmentStatus.OK, 0),
                 "damaged": status_map.get(EquipmentStatus.DAMAGED, 0),
@@ -357,6 +357,24 @@ class DepartmentAccessoriesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewse
         return super().get_serializer(*args, **kwargs)
     
 
+
+class DepartmentAccessoryDashboardView(
+    AccessoryDashboardMixin,
+    APIView
+):
+    permission_classes = [IsAuthenticated]
+
+    def get_rooms(self, public_id):
+        return Room.objects.filter(
+            location__department__public_id=public_id
+        )
+
+    def get(self, request, public_id):
+        period = self.get_period(request)
+        rooms = self.get_rooms(public_id)
+        data = self.build_dashboard_response(rooms, period)
+        return Response(data)
+    
 class DepartmentAccessoriesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = AccessoryFullSerializer
     lookup_field = 'public_id'

--- a/db_inventory/viewsets/sites/department_viewsets.py
+++ b/db_inventory/viewsets/sites/department_viewsets.py
@@ -18,6 +18,10 @@ from db_inventory.serializers.accessories import AccessoryFullSerializer
 from db_inventory.serializers.rooms import RoomSerializer
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import mixins
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from db_inventory.models.assets import EquipmentStatus
+from rest_framework.views import APIView
 
 
 
@@ -206,6 +210,59 @@ class DepartmentEquipmentViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet
         return super().get_serializer(*args, **kwargs)
     
 
+class DepartmentEquipmentDashboardView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, public_id):
+
+        equipment_qs = Equipment.objects.filter(
+            room__location__department__public_id=public_id
+        ).select_related(
+            "room__location__department"
+        )
+
+        status_counts = (
+            equipment_qs
+            .values("status")
+            .annotate(count=Count("id"))
+        )
+
+        status_map = {
+            row["status"]: row["count"]
+            for row in status_counts
+        }
+
+        total_equipment = sum(status_map.values())
+
+
+        active_assignments = EquipmentAssignment.objects.filter(
+            equipment__in=equipment_qs,
+            returned_at__isnull=True
+        ).count()
+
+        available = equipment_qs.filter(
+            status=EquipmentStatus.OK,
+            active_assignment__returned_at__isnull=True
+        ).count()
+
+        return Response({
+            "equipment_health": {
+                "total": total_equipment,
+                "available": available,
+                "under_repair": status_map.get(EquipmentStatus.UNDER_REPAIR, 0),
+                "ok": status_map.get(EquipmentStatus.OK, 0),
+                "damaged": status_map.get(EquipmentStatus.DAMAGED, 0),
+                "lost": status_map.get(EquipmentStatus.LOST, 0),
+            },
+            "utilization": {
+                "active_assignments": active_assignments,
+                "percent_assigned": round(
+                    (active_assignments / total_equipment * 100)
+                    if total_equipment else 0,
+                    1
+                ),
+            },
+        })
 
 class DepartmentEquipmentMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = EquipmentSerializer

--- a/db_inventory/viewsets/sites/location_viewsets.py
+++ b/db_inventory/viewsets/sites/location_viewsets.py
@@ -80,25 +80,30 @@ class LocationListViewSet(ScopeFilterMixin, viewsets.ModelViewSet):
 
     serializer_class = LocationListSerializer 
 
-class LocationRoomsView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+class LocationRoomsView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of rooms in a given location"""
     serializer_class = LocationRoomSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
 
-    exclude_filter_fields = ["department", "location"]
-
-    permission_classes =[LocationPermission]
-
-    def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Room.objects.filter(location__public_id=location_id)
+    permission_classes = [LocationPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
+    search_fields = ["name"]
     filterset_class = RoomFilter
+    exclude_filter_fields = ["department", "location"]
 
     pagination_class = FlexiblePagination
+
+    def get_queryset(self):
+        location_id = self.kwargs["public_id"]
+
+        qs = Room.objects.filter(location__public_id=location_id)
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
 
 
 class LocationRoomsMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
@@ -116,27 +121,25 @@ class LocationRoomsMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
         return Room.objects.filter(location__public_id=location_id)
 
 
-class LocationUsersView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+class LocationUsersView( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of users in a given location"""
     serializer_class = UserAreaSerializer
 
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['user__email']
+    permission_classes = [UserPermission]
 
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    search_fields = ["user__email"]
+    filterset_class = AreaUserFilter
     exclude_filter_fields = ["department", "location"]
 
-    filterset_class =  AreaUserFilter
-
-    permission_classes =[UserPermission]
-
     pagination_class = FlexiblePagination
-    
 
     def get_queryset(self):
-        location_id = self.kwargs.get("public_id")
+        location_id = self.kwargs["public_id"]
 
-        return (
-            UserLocation.objects.filter(
+        qs = (
+            UserLocation.objects
+            .filter(
                 is_current=True,
                 room__location__public_id=location_id,
             )
@@ -145,57 +148,54 @@ class LocationUsersView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelVie
                 "room",
             )
         )
-    
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
         return super().get_serializer(*args, **kwargs)
 
+
     
-class LocationUsersMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = UserAreaSerializer
-    pagination_class = None
 
-    permission_classes =[UserPermission]
 
-    def get_queryset(self):
-        location_id = self.kwargs.get("public_id")
-
-        return (
-            UserLocation.objects.filter(
-                is_current=True,
-                room__location__public_id=location_id,
-            )
-            .select_related(
-                "user",
-                "room",
-            )
-        )
-
-class LocationEquipmentView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+class LocationEquipmentView( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of equipment in a given location"""
     serializer_class = EquipmentSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
 
-    exclude_filter_fields = ["department", "location"]
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
+    search_fields = ["name"]
     filterset_class = EquipmentFilter
-
-    permission_classes =[AssetPermission]
+    exclude_filter_fields = ["department", "location"]
 
     pagination_class = FlexiblePagination
 
-
     def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Equipment.objects.filter(room__location__public_id=location_id).order_by('-id')
-    
+        location_id = self.kwargs["public_id"]
+
+        qs = (
+            Equipment.objects
+            .filter(room__location__public_id=location_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
         return super().get_serializer(*args, **kwargs)
 
 class LocationEquipmentDashboardView(APIView):
@@ -250,52 +250,39 @@ class LocationEquipmentDashboardView(APIView):
             },
         })
 
-class LocationEquipmentMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = EquipmentSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
 
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    permission_classes =[AssetPermission]
-
-    def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Equipment.objects.filter(room__location__public_id=location_id).order_by('-id')[:20]
-    
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        return super().get_serializer(*args, **kwargs)
-
-
-class LocationConsumablesView(ScopeFilterMixin, ExcludeFiltersMixin,viewsets.ModelViewSet):
+class LocationConsumablesView( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of consumables in a given location"""
     serializer_class = ConsumableAreaReaSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
+
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    exclude_filter_fields = ["department", "location"]
-
+    search_fields = ["name"]
     filterset_class = ConsumableFilter
-
-    permission_classes =[AssetPermission]
+    exclude_filter_fields = ["department", "location"]
 
     pagination_class = FlexiblePagination
 
-
     def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
+        location_id = self.kwargs["public_id"]
 
-        return Consumable.objects.filter(room__location__public_id=location_id).order_by('-id')
-    
+        qs = (
+            Consumable.objects
+            .filter(room__location__public_id=location_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        return super().get_serializer(*args, **kwargs)
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
 
 class LocationConsumableDashboardView( ConsumableDashboardMixin, APIView):
     permission_classes = [IsAuthenticated]
@@ -310,52 +297,40 @@ class LocationConsumableDashboardView( ConsumableDashboardMixin, APIView):
 
         data = self.build_dashboard_response(rooms, period)
         return Response(data)
-       
-class LocationConsumablesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = ConsumableAreaReaSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
 
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    permission_classes =[AssetPermission]
-
-    def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Consumable.objects.filter(room__location__public_id=location_id).order_by('-id')[:20]
     
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        return super().get_serializer(*args, **kwargs)
-    
-    
-    
-class LocationAccessoriesView(ScopeFilterMixin,ExcludeFiltersMixin, viewsets.ModelViewSet):
+class LocationAccessoriesView( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of accessories in a given location"""
     serializer_class = AccessoryFullSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
 
-    exclude_filter_fields = ["department", "location"]
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
+    search_fields = ["name"]
     filterset_class = AccessoryFilter
-
-    permission_classes =[AssetPermission]
+    exclude_filter_fields = ["department", "location"]
 
     pagination_class = FlexiblePagination
 
     def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Accessory.objects.filter(room__location__public_id=location_id).order_by('-id')
-    
+        location_id = self.kwargs["public_id"]
+
+        qs = (
+            Accessory.objects
+            .filter(room__location__public_id=location_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
 
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
         return super().get_serializer(*args, **kwargs)
     
 
@@ -377,68 +352,44 @@ class LocationAccessoryDashboardView(
         return Response(data)
     
     
-class LocationAccessoriesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = AccessoryFullSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    permission_classes =[AssetPermission]
-
-    def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Accessory.objects.filter(room__location__public_id=location_id).order_by('-id')[:20]
-    
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        return super().get_serializer(*args, **kwargs)
-    
 
 
-class LocationComponentsViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet):
+class LocationComponentsViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ReadOnlyModelViewSet, ):
     """Retrieves a list of components in a given location"""
     serializer_class = LocationComponentSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
 
-    permission_classes=[AssetPermission]
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
+    search_fields = ["name"]
+    filterset_class = ComponentFilter
     exclude_filter_fields = ["department", "location"]
 
-    filterset_class = ComponentFilter
-
     pagination_class = FlexiblePagination
-    
+
     def get_queryset(self):
         location_id = self.kwargs.get("public_id")
 
         if not location_id:
             return Component.objects.none()
 
-        return Component.objects.filter(
-            equipment__room__location__public_id=location_id
-        ).select_related(
-            "equipment__room__location__department" 
+        qs = (
+            Component.objects
+            .filter(
+                equipment__room__location__public_id=location_id
+            )
+            .select_related(
+                "equipment__room__location__department"
+            )
         )
-    
-class LocationComponentsMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = LocationComponentSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
 
-    permission_classes=[AssetPermission]
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
 
-    def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return (
-            Component.objects.filter(equipment__room__location__public_id=location_id)
-            .order_by('-id')[:20]
-        )
+        return qs
+
 
 class LocationRolesViewSet(ScopeFilterMixin,RoleVisibilityMixin,viewsets.ReadOnlyModelViewSet):
     """

--- a/db_inventory/viewsets/sites/location_viewsets.py
+++ b/db_inventory/viewsets/sites/location_viewsets.py
@@ -6,7 +6,7 @@ from db_inventory.serializers.users import UserAreaSerializer
 from db_inventory.serializers.assignment import EquipmentAssignmentSerializer
 from db_inventory.serializers.consumables import ConsumableAreaReaSerializer
 from db_inventory.serializers.accessories import AccessoryFullSerializer
-from db_inventory.models.assets import Equipment, Consumable, Accessory, Component
+from db_inventory.models.assets import Equipment, Consumable, Accessory, Component, EquipmentStatus
 from db_inventory.models.site import Location, Room, UserLocation
 from db_inventory.models.roles import RoleAssignment
 from django_filters.rest_framework import DjangoFilterBackend
@@ -19,7 +19,11 @@ from db_inventory.pagination import FlexiblePagination
 from django.db.models import Q
 from db_inventory.mixins import AuditMixin
 from rest_framework import mixins
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
 
+from django.db.models import Count
 from db_inventory.permissions.assets import HasAssignmentScopePermission
 
 class LocationModelViewSet(AuditMixin, ScopeFilterMixin, viewsets.ModelViewSet):
@@ -193,7 +197,59 @@ class LocationEquipmentView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.Mode
         kwargs['exclude_department'] = True
         kwargs['exclude_location'] = True
         return super().get_serializer(*args, **kwargs)
-    
+
+class LocationEquipmentDashboardView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, public_id):
+
+        equipment_qs = Equipment.objects.filter(
+            room__location__public_id=public_id
+        ).select_related(
+            "room__location"
+        )
+        status_counts = (
+            equipment_qs
+            .values("status")
+            .annotate(count=Count("id"))
+        )
+
+        status_map = {
+            row["status"]: row["count"]
+            for row in status_counts
+        }
+
+        total_equipment = sum(status_map.values())
+
+        active_assignments = EquipmentAssignment.objects.filter(
+            equipment__in=equipment_qs,
+            returned_at__isnull=True
+        ).count()
+
+
+        available = equipment_qs.filter(
+            status=EquipmentStatus.OK,
+            active_assignment__returned_at__isnull=True
+        ).count()
+
+        return Response({
+            "equipment_health": {
+                "total": total_equipment,
+                "available": available,
+                "under_repair": status_map.get(EquipmentStatus.UNDER_REPAIR, 0),
+                "damaged": status_map.get(EquipmentStatus.DAMAGED, 0),
+                "lost": status_map.get(EquipmentStatus.LOST, 0),
+            },
+            "utilization": {
+                "active_assignments": active_assignments,
+                "percent_assigned": round(
+                    (active_assignments / total_equipment * 100)
+                    if total_equipment else 0,
+                    1
+                ),
+            },
+        })
+
 class LocationEquipmentMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = EquipmentSerializer
     lookup_field = 'public_id'

--- a/db_inventory/viewsets/sites/location_viewsets.py
+++ b/db_inventory/viewsets/sites/location_viewsets.py
@@ -12,7 +12,7 @@ from db_inventory.models.roles import RoleAssignment
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from db_inventory.filters import *
-from db_inventory.mixins import AccessoryDashboardMixin, ScopeFilterMixin, ExcludeFiltersMixin, RoleVisibilityMixin
+from db_inventory.mixins import AccessoryDashboardMixin, ConsumableDashboardMixin, ScopeFilterMixin, ExcludeFiltersMixin, RoleVisibilityMixin
 from db_inventory.permissions import LocationPermission, AssetPermission, RolePermission, UserPermission
 from django.db.models import Case, When, Value, IntegerField
 from db_inventory.pagination import FlexiblePagination
@@ -22,7 +22,7 @@ from rest_framework import mixins
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
-
+from django.shortcuts import get_object_or_404
 from django.db.models import Count
 from db_inventory.permissions.assets import HasAssignmentScopePermission
 
@@ -296,7 +296,21 @@ class LocationConsumablesView(ScopeFilterMixin, ExcludeFiltersMixin,viewsets.Mod
         kwargs['exclude_department'] = True
         kwargs['exclude_location'] = True
         return super().get_serializer(*args, **kwargs)
-    
+
+class LocationConsumableDashboardView( ConsumableDashboardMixin, APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_rooms(self, public_id):
+        location = get_object_or_404(Location, public_id=public_id)
+        return location.rooms.all()
+
+    def get(self, request, public_id):
+        rooms = self.get_rooms(public_id)
+        period = self.get_period(request)
+
+        data = self.build_dashboard_response(rooms, period)
+        return Response(data)
+       
 class LocationConsumablesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = ConsumableAreaReaSerializer
     lookup_field = 'public_id'

--- a/db_inventory/viewsets/sites/location_viewsets.py
+++ b/db_inventory/viewsets/sites/location_viewsets.py
@@ -26,59 +26,43 @@ from django.shortcuts import get_object_or_404
 from django.db.models import Count
 from db_inventory.permissions.assets import HasAssignmentScopePermission
 
-class LocationModelViewSet(AuditMixin, ScopeFilterMixin, viewsets.ModelViewSet):
 
-    """ViewSet for managing Location objects.
-    This viewset provides `list`, `create`, `retrieve`, `update`, and `destroy` actions for Location objects."""
+class LocationViewSet(AuditMixin, ScopeFilterMixin, viewsets.ModelViewSet):
+    """ViewSet for managing Location objects"""
 
-    queryset = Location.objects.all()
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
+    permission_classes = [LocationPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['^name', 'name']
-
-    permission_classes =[LocationPermission]
-
+    search_fields = ["^name", "name"]
     filterset_class = LocationFilter
 
     pagination_class = FlexiblePagination
 
     def get_serializer_class(self):
-        if self.action in ['create', 'update', 'partial_update']:
+        if self.action in ["create", "update", "partial_update"]:
             return LocationWriteSerializer
+
+        # Light list endpoint (unpaginated)
+        if self.action == "list" and self.pagination_class is None:
+            return LocationListSerializer
+
         return LocationReadSerializer
-    
 
     def get_queryset(self):
-        qs = super().get_queryset()
-        search_term = self.request.query_params.get('search', None)
+        qs = Location.objects.all()
+        search_term = self.request.query_params.get("search")
 
         if search_term:
-            # Annotate results: 1 if starts with search_term, 2 otherwise
             qs = qs.annotate(
                 starts_with_order=Case(
                     When(name__istartswith=search_term, then=Value(1)),
                     default=Value(2),
-                    output_field=IntegerField()
+                    output_field=IntegerField(),
                 )
-            ).order_by('starts_with_order', 'name')  # starts-with results first
+            ).order_by("starts_with_order", "name")
 
         return qs
-    
-class LocationListViewSet(ScopeFilterMixin, viewsets.ModelViewSet):
-
-    """Returns a flat list of location objects"""
-
-    queryset = Location.objects.all()
-    lookup_field = 'public_id'
-    pagination_class = None 
-
-    filter_backends = [SearchFilter]
-    search_fields = ['name']
-
-    permission_classes =[LocationPermission]
-
-    serializer_class = LocationListSerializer 
 
 class LocationRoomsView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of rooms in a given location"""
@@ -105,20 +89,6 @@ class LocationRoomsView(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelVie
 
         return qs
 
-
-class LocationRoomsMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = LocationRoomSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    permission_classes =[LocationPermission]
-
-    def get_queryset(self):
-        location_id = self.kwargs.get('public_id')
-        return Room.objects.filter(location__public_id=location_id)
 
 
 class LocationUsersView( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):

--- a/db_inventory/viewsets/sites/location_viewsets.py
+++ b/db_inventory/viewsets/sites/location_viewsets.py
@@ -12,7 +12,7 @@ from db_inventory.models.roles import RoleAssignment
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from db_inventory.filters import *
-from db_inventory.mixins import ScopeFilterMixin, ExcludeFiltersMixin, RoleVisibilityMixin
+from db_inventory.mixins import AccessoryDashboardMixin, ScopeFilterMixin, ExcludeFiltersMixin, RoleVisibilityMixin
 from db_inventory.permissions import LocationPermission, AssetPermission, RolePermission, UserPermission
 from django.db.models import Case, When, Value, IntegerField
 from db_inventory.pagination import FlexiblePagination
@@ -345,6 +345,24 @@ class LocationAccessoriesView(ScopeFilterMixin,ExcludeFiltersMixin, viewsets.Mod
         return super().get_serializer(*args, **kwargs)
     
 
+class LocationAccessoryDashboardView(
+    AccessoryDashboardMixin,
+    APIView
+):
+    permission_classes = [IsAuthenticated]
+
+    def get_rooms(self, public_id):
+        return Room.objects.filter(
+            location__public_id=public_id
+        )
+
+    def get(self, request, public_id):
+        period = self.get_period(request)
+        rooms = self.get_rooms(public_id)
+        data = self.build_dashboard_response(rooms, period)
+        return Response(data)
+    
+    
 class LocationAccessoriesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
     serializer_class = AccessoryFullSerializer
     lookup_field = 'public_id'

--- a/db_inventory/viewsets/sites/room_viewsets.py
+++ b/db_inventory/viewsets/sites/room_viewsets.py
@@ -12,7 +12,11 @@ from db_inventory.pagination import FlexiblePagination
 from db_inventory.serializers import *
 from django.db.models import Q
 from rest_framework import mixins
-
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from db_inventory.models.assets import EquipmentStatus
+from django.db.models import Count
 
 class RoomModelViewSet(AuditMixin,ScopeFilterMixin, viewsets.ModelViewSet):
     """ViewSet for managing Room objects.
@@ -131,6 +135,74 @@ class RoomEquipmentViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.Model
         kwargs['exclude_location'] = True
         kwargs['exclude_room'] = True
         return super().get_serializer(*args, **kwargs)
+    
+
+class RoomEquipmentDashboardView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, public_id):
+        # ---------------------------------------------
+        # 1. Base queryset: all equipment in the room
+        # ---------------------------------------------
+        equipment_qs = Equipment.objects.filter(
+            room__public_id=public_id
+        ).select_related(
+            "room"
+        )
+
+        # ---------------------------------------------
+        # 2. Equipment status aggregation
+        # ---------------------------------------------
+        status_counts = (
+            equipment_qs
+            .values("status")
+            .annotate(count=Count("id"))
+        )
+
+        status_map = {
+            row["status"]: row["count"]
+            for row in status_counts
+        }
+
+        total_equipment = sum(status_map.values())
+
+        # ---------------------------------------------
+        # 3. Active assignments
+        # ---------------------------------------------
+        active_assignments = EquipmentAssignment.objects.filter(
+            equipment__in=equipment_qs,
+            returned_at__isnull=True
+        ).count()
+
+        # ---------------------------------------------
+        # 4. Available equipment
+        # (OK + not currently assigned)
+        # ---------------------------------------------
+        available = equipment_qs.filter(
+            status=EquipmentStatus.OK,
+            active_assignment__returned_at__isnull=True
+        ).count()
+
+        # ---------------------------------------------
+        # 5. Response
+        # ---------------------------------------------
+        return Response({
+            "equipment_health": {
+                "total": total_equipment,
+                "available": available,
+                "under_repair": status_map.get(EquipmentStatus.UNDER_REPAIR, 0),
+                "damaged": status_map.get(EquipmentStatus.DAMAGED, 0),
+                "lost": status_map.get(EquipmentStatus.LOST, 0),
+            },
+            "utilization": {
+                "active_assignments": active_assignments,
+                "percent_assigned": round(
+                    (active_assignments / total_equipment * 100)
+                    if total_equipment else 0,
+                    1
+                ),
+            },
+        })
     
 
 class RoomConsumablesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):

--- a/db_inventory/viewsets/sites/room_viewsets.py
+++ b/db_inventory/viewsets/sites/room_viewsets.py
@@ -6,7 +6,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from db_inventory.filters import *
 from db_inventory.permissions import RoomPermission, AssetPermission, UserPermission
-from db_inventory.mixins import AccessoryDashboardMixin, ScopeFilterMixin, AuditMixin, ExcludeFiltersMixin, RoleVisibilityMixin
+from db_inventory.mixins import AccessoryDashboardMixin, ConsumableDashboardMixin, ScopeFilterMixin, AuditMixin, ExcludeFiltersMixin, RoleVisibilityMixin
 from django.db.models import Case, When, Value, IntegerField
 from db_inventory.pagination import FlexiblePagination
 from db_inventory.serializers import *
@@ -17,6 +17,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from db_inventory.models.assets import EquipmentStatus
 from django.db.models import Count
+from django.shortcuts import get_object_or_404
 
 class RoomModelViewSet(AuditMixin,ScopeFilterMixin, viewsets.ModelViewSet):
     """ViewSet for managing Room objects.
@@ -232,7 +233,19 @@ class RoomConsumablesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.Mod
         kwargs['exclude_room'] = True
         return super().get_serializer(*args, **kwargs)
     
-    
+class RoomConsumableDashboardView( ConsumableDashboardMixin, APIView, ):
+    permission_classes = [IsAuthenticated]
+
+    def get_rooms(self, public_id):
+        room = get_object_or_404(Room, public_id=public_id)
+        return Room.objects.filter(id=room.id)
+
+    def get(self, request, public_id):
+        rooms = self.get_rooms(public_id)
+        period = self.get_period(request)
+
+        data = self.build_dashboard_response(rooms, period)
+        return Response(data)   
 
 class RoomAccessoriesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
     """Retrieves a list of accessories in a given room"""

--- a/db_inventory/viewsets/sites/room_viewsets.py
+++ b/db_inventory/viewsets/sites/room_viewsets.py
@@ -19,82 +19,63 @@ from db_inventory.models.assets import EquipmentStatus
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
 
-class RoomModelViewSet(AuditMixin,ScopeFilterMixin, viewsets.ModelViewSet):
-    """ViewSet for managing Room objects.
-    This viewset provides `list`, `create`, `retrieve`, `update`, and `destroy` actions for Room objects."""
-        
-    queryset = Room.objects.all().order_by("id")
-    lookup_field = 'public_id'
+
+    
+class RoomViewSet(AuditMixin, ScopeFilterMixin, viewsets.ModelViewSet):
+    lookup_field = "public_id"
+    permission_classes = [RoomPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['^name', 'name']
+    search_fields = ["^name", "name"]
+    filterset_class = RoomFilter
 
     pagination_class = FlexiblePagination
 
-    filterset_class = RoomFilter
-
-    permission_classes = [RoomPermission]
-
-
     def get_serializer_class(self):
-        if self.action in ['create', 'update', 'partial_update']:
+        if self.action in ["create", "update", "partial_update"]:
             return RoomWriteSerializer
+
+        # Light list endpoint
+        if self.action == "list" and self.pagination_class is None:
+            return RoomListSerializer
+
         return RoomReadSerializer
     
-
     def get_queryset(self):
-        qs = super().get_queryset()
-        search_term = self.request.query_params.get('search', None)
+        qs = Room.objects.all().order_by("id")
+        search_term = self.request.query_params.get("search")
 
         if search_term:
-            # Annotate results: 1 if starts with search_term, 2 otherwise
             qs = qs.annotate(
                 starts_with_order=Case(
                     When(name__istartswith=search_term, then=Value(1)),
                     default=Value(2),
-                    output_field=IntegerField()
+                    output_field=IntegerField(),
                 )
-            ).order_by('starts_with_order', 'name')  # starts-with results first
+            ).order_by("starts_with_order", "name")
 
         return qs
-    
-
-        
-class RoomListViewset(ScopeFilterMixin, viewsets.ModelViewSet):
-   
-    queryset = Room.objects.all()
-    lookup_field = 'public_id'
-    pagination_class = None
-
-    filter_backends = [SearchFilter]
-    search_fields = ['name']
-
-    serializer_class = RoomListSerializer
-
-    permission_classes = [RoomPermission]
 
     
-class RoomUsersViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+class RoomUsersViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of users in a given room"""
     serializer_class = UserAreaSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
+
+    permission_classes = [UserPermission]
 
     filter_backends = [DjangoFilterBackend]
     filterset_class = AreaUserFilter
+    exclude_filter_fields = ["department", "location", "room"]
 
     pagination_class = FlexiblePagination
 
-    exclude_filter_fields = ["department", "location", "room"]
-
-    permission_classes = [UserPermission]
-    
-
-
     def get_queryset(self):
-        room_id = self.kwargs.get("public_id")
+        room_id = self.kwargs["public_id"]
 
-        return (
-            UserLocation.objects.filter(
+        qs = (
+            UserLocation.objects
+            .filter(
                 is_current=True,
                 room__public_id=room_id,
             )
@@ -103,38 +84,52 @@ class RoomUsersViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelView
                 "room",
             )
         )
-    
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
-        return super().get_serializer(*args, **kwargs)
 
-class RoomEquipmentViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
+    def get_serializer(self, *args, **kwargs):
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
+        kwargs["exclude_room"] = True
+        return super().get_serializer(*args, **kwargs)
+    
+class RoomEquipmentViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of equipment in a given room"""
     serializer_class = EquipmentSerializer
-    lookup_field = 'public_id'
-
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    exclude_filter_fields = ["department", "location", "room"]
-
-    filterset_class = EquipmentFilter
-
-    pagination_class = FlexiblePagination
+    lookup_field = "public_id"
 
     permission_classes = [AssetPermission]
 
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    search_fields = ["name"]
+    filterset_class = EquipmentFilter
+    exclude_filter_fields = ["department", "location", "room"]
+
+    pagination_class = FlexiblePagination
 
     def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Equipment.objects.filter(room__public_id=room_id).order_by('-id')
-    
+        room_id = self.kwargs["public_id"]
+
+        qs = (
+            Equipment.objects
+            .filter(room__public_id=room_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
+        kwargs["exclude_room"] = True
         return super().get_serializer(*args, **kwargs)
     
 
@@ -206,31 +201,39 @@ class RoomEquipmentDashboardView(APIView):
         })
     
 
-class RoomConsumablesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+class RoomConsumablesViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of consumables in a given room"""
     serializer_class = ConsumableAreaReaSerializer
-    lookup_field = 'public_id'
-
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    exclude_filter_fields = ["department", "location", "room"]
-
-    filterset_class = ConsumableFilter
-
-    pagination_class = FlexiblePagination
+    lookup_field = "public_id"
 
     permission_classes = [AssetPermission]
 
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    search_fields = ["name"]
+    filterset_class = ConsumableFilter
+    exclude_filter_fields = ["department", "location", "room"]
+
+    pagination_class = FlexiblePagination
 
     def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Consumable.objects.filter(room__public_id=room_id).order_by('-id')
-    
+        room_id = self.kwargs["public_id"]
+
+        qs = (
+            Consumable.objects
+            .filter(room__public_id=room_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
+        kwargs["exclude_room"] = True
         return super().get_serializer(*args, **kwargs)
     
 class RoomConsumableDashboardView( ConsumableDashboardMixin, APIView, ):
@@ -247,30 +250,39 @@ class RoomConsumableDashboardView( ConsumableDashboardMixin, APIView, ):
         data = self.build_dashboard_response(rooms, period)
         return Response(data)   
 
-class RoomAccessoriesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet):
+class RoomAccessoriesViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of accessories in a given room"""
     serializer_class = AccessoryFullSerializer
-    lookup_field = 'public_id'
-
-    exclude_filter_fields = ["department", "location", "room"]
-
-    filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    filterset_class = AccessoryFilter
-
-    pagination_class = FlexiblePagination
+    lookup_field = "public_id"
 
     permission_classes = [AssetPermission]
 
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    search_fields = ["name"]
+    filterset_class = AccessoryFilter
+    exclude_filter_fields = ["department", "location", "room"]
+
+    pagination_class = FlexiblePagination
+
     def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Accessory.objects.filter(room__public_id=room_id).order_by('-id')
-    
+        room_id = self.kwargs["public_id"]
+
+        qs = (
+            Accessory.objects
+            .filter(room__public_id=room_id)
+            .order_by("-id")
+        )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
+
     def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
+        kwargs["exclude_department"] = True
+        kwargs["exclude_location"] = True
+        kwargs["exclude_room"] = True
         return super().get_serializer(*args, **kwargs)
     
 class RoomAccessoryDashboardView(
@@ -290,108 +302,35 @@ class RoomAccessoryDashboardView(
         data = self.build_dashboard_response(rooms, period)
         return Response(data)
 
-class RoomComponentsViewSet(ScopeFilterMixin,ExcludeFiltersMixin,viewsets.ModelViewSet):
+class RoomComponentsViewSet( ScopeFilterMixin, ExcludeFiltersMixin, viewsets.ModelViewSet, ):
     """Retrieves a list of components in a given room"""
     serializer_class = ComponentSerializer
-    lookup_field = 'public_id'
+    lookup_field = "public_id"
+
+    permission_classes = [AssetPermission]
 
     filter_backends = [DjangoFilterBackend, SearchFilter]
-    search_fields = ['name']
-
-    exclude_filter_fields = ["department", "location", "room"]
-
+    search_fields = ["name"]
     filterset_class = ComponentFilter
+    exclude_filter_fields = ["department", "location", "room"]
 
     pagination_class = FlexiblePagination
 
-    permission_classes = [AssetPermission]
-
     def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Component.objects.filter(equipment__room__public_id=room_id).order_by('-id')
-    
+        room_id = self.kwargs["public_id"]
 
-class RoomComponentsMiniViewSet(ScopeFilterMixin,viewsets.ReadOnlyModelViewSet):
-    serializer_class = ComponentSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-    permission_classes = [AssetPermission]
-
-    def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Component.objects.filter(equipment__room__public_id=room_id).order_by('-id')[:20]
-
-
-class RoomUsersMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = UserAreaSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-    permission_classes = [UserPermission]
-
-    def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return (
-            UserLocation.objects.filter(room__public_id=room_id)
-            .select_related('user', 'room')
-            .order_by('-id')[:20]
+        qs = (
+            Component.objects
+            .filter(equipment__room__public_id=room_id)
+            .order_by("-id")
         )
+
+        # Light endpoint → unpaginated + capped
+        if self.pagination_class is None:
+            qs = qs[:20]
+
+        return qs
     
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
-        return super().get_serializer(*args, **kwargs)
-    
-
-class RoomEquipmentMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = EquipmentSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-    permission_classes = [AssetPermission]
-
-    def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Equipment.objects.filter(room__public_id=room_id).order_by('-id')[:20]
-    
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
-        return super().get_serializer(*args, **kwargs)
-
-
-class RoomConsumablesMiniViewSet(ScopeFilterMixin, viewsets.ReadOnlyModelViewSet):
-    serializer_class = ConsumableAreaReaSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-    permission_classes = [AssetPermission]
-
-    def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Consumable.objects.filter(room__public_id=room_id).order_by('-id')[:20]
-    
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
-        return super().get_serializer(*args, **kwargs)
-
-
-class RoomAccessoriesMiniViewSet(ScopeFilterMixin,viewsets.ReadOnlyModelViewSet):
-    serializer_class = AccessoryFullSerializer
-    lookup_field = 'public_id'
-    pagination_class = None
-    permission_classes = [AssetPermission]
-
-    def get_queryset(self):
-        room_id = self.kwargs.get('public_id')
-        return Accessory.objects.filter(room__public_id=room_id).order_by('-id')[:20]
-    
-    def get_serializer(self, *args, **kwargs):
-        kwargs['exclude_department'] = True
-        kwargs['exclude_location'] = True
-        kwargs['exclude_room'] = True
-        return super().get_serializer(*args, **kwargs)
 
 
 class RoomRolesViewSet(ScopeFilterMixin,RoleVisibilityMixin,viewsets.ReadOnlyModelViewSet):

--- a/db_inventory/viewsets/sites/room_viewsets.py
+++ b/db_inventory/viewsets/sites/room_viewsets.py
@@ -6,7 +6,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import SearchFilter
 from db_inventory.filters import *
 from db_inventory.permissions import RoomPermission, AssetPermission, UserPermission
-from db_inventory.mixins import ScopeFilterMixin, AuditMixin, ExcludeFiltersMixin, RoleVisibilityMixin
+from db_inventory.mixins import AccessoryDashboardMixin, ScopeFilterMixin, AuditMixin, ExcludeFiltersMixin, RoleVisibilityMixin
 from django.db.models import Case, When, Value, IntegerField
 from db_inventory.pagination import FlexiblePagination
 from db_inventory.serializers import *
@@ -260,6 +260,22 @@ class RoomAccessoriesViewSet(ScopeFilterMixin, ExcludeFiltersMixin, viewsets.Mod
         kwargs['exclude_room'] = True
         return super().get_serializer(*args, **kwargs)
     
+class RoomAccessoryDashboardView(
+    AccessoryDashboardMixin,
+    APIView
+):
+    permission_classes = [IsAuthenticated]
+
+    def get_rooms(self, public_id):
+        return Room.objects.filter(
+            public_id=public_id
+        )
+
+    def get(self, request, public_id):
+        period = self.get_period(request)
+        rooms = self.get_rooms(public_id)
+        data = self.build_dashboard_response(rooms, period)
+        return Response(data)
 
 class RoomComponentsViewSet(ScopeFilterMixin,ExcludeFiltersMixin,viewsets.ModelViewSet):
     """Retrieves a list of components in a given room"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,16 @@ services:
   celery_beat:
     build: .
     container_name: inventory_celery_beat
-    command: celery -A inventory beat -l info
+    command: >
+      celery -A inventory beat -l info
+      --scheduler django_celery_beat.schedulers:DatabaseScheduler
     volumes:
       - .:/app
     env_file:
       - .env.dev
+    environment:
+      DJANGO_ENV: dev
+      DJANGO_SETTINGS_MODULE: inventory.settings
     depends_on:
       - redis
       - web


### PR DESCRIPTION
## Added Dashboard APIView for various assets

To support frontend dashboard components dashboard views were made for various assets, these classes produced aggregated snap snapshots of their respective models' to be sued my frontend components.


## Refactored Viewset and simplified logic

- Removed redundant *List / *Mini ViewSets across departments, locations, rooms, and assets and Standardized them into on one ViewSet per resource. Doing this, centralized queryset logic and serializer selection inside ViewSet

Kept "light" endpoints for flat lists by overriding pagination at the URL level

- Centralized queryset logic and serializer selection inside ViewSets
